### PR TITLE
Feat/issue url checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.100"
 tokio = { version = "1.29.1", features = ["full"] }
+url = "2.4.0"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ For example: `feature/PROJECT-1078-some-jira-ticket-title`
 ### Mac
 
 1. Download the latest release
+
 ```bash
 curl -OL https://github.com/jtstott/jira-branches/releases/latest/download/jira_branches-x86_64-apple-darwin.tar.gz && \
 tar -xzvf jira_branches-x86_64-apple-darwin.tar.gz && \
 rm jira_branches-x86_64-apple-darwin.tar.gz
 ```
+
 2. Move the binary into a directory in your local path, e.g. `/usr/local/bin/`
 2. Authenticate with Jira by creating the file `~/.config/jira-branches/auth.json` and add your Jira username and
    password:
@@ -65,11 +67,12 @@ jira_branches --help
 
 ### Checkout branch
 
-The `checkout` command takes an `--issue-id` argument, and will checkout a git branch for the current git repository
+The `checkout` command takes an `--issue` argument, and will checkout a git branch for the current git repository
 formatted to the configured template. If the branch doesn't already exist it will be created.
 
-To checkout to a git branch for a given Jira ticket ID (`ID`), run the `checkout` command, supplying the ticket ID
-with `--issue-id` or `-i`:
+To checkout to a git branch for a given Jira ticket ID (`ID`), or Jira ticket URL, run the `checkout` command, supplying
+the ticket ID or ticket URL
+with `--issue` or `-i`:
 
 ```shell
 jira_branches checkout -i ID

--- a/src/cli/cli_parser.rs
+++ b/src/cli/cli_parser.rs
@@ -26,9 +26,9 @@ pub struct Cli {
 pub enum Commands {
     /// Checkout branch for a Jira issue
     Checkout {
-        /// Jira issue ID
+        /// Jira issue ID or URL
         #[arg(short, long)]
-        issue_id: String,
+        issue: String,
     }
 }
 

--- a/src/cli/command_handler.rs
+++ b/src/cli/command_handler.rs
@@ -6,7 +6,7 @@ use crate::jira::issue;
 
 pub async fn handle_command(cli: Cli, config: AppConfig) -> Result<(), String> {
     match cli.command {
-        cli_parser::Commands::Checkout { issue_id } => { handle_checkout(&config, issue_id).await?; }
+        cli_parser::Commands::Checkout { issue } => { handle_checkout(&config, issue).await?; }
     }
 
     // if let Some(config_path) = cli.config.as_deref() {
@@ -16,9 +16,10 @@ pub async fn handle_command(cli: Cli, config: AppConfig) -> Result<(), String> {
     Ok(())
 }
 
-async fn handle_checkout(config: &AppConfig, issue_id: String) -> Result<(), String> {
-    let issue_details = issue::get_issue(issue_id.as_str(), &config).await;
+async fn handle_checkout(config: &AppConfig, issue: String) -> Result<(), String> {
+    let issue_details = issue::get_issue(issue.as_str(), &config).await;
+    println!("{:?}", issue_details);
     let branch_name = template::interpret_branch_template(&config.config, issue_details?);
-    checkout::checkout_branch(branch_name.as_str());
+    // checkout::checkout_branch(branch_name.as_str());
     Ok(())
 }

--- a/src/cli/command_handler.rs
+++ b/src/cli/command_handler.rs
@@ -18,8 +18,7 @@ pub async fn handle_command(cli: Cli, config: AppConfig) -> Result<(), String> {
 
 async fn handle_checkout(config: &AppConfig, issue: String) -> Result<(), String> {
     let issue_details = issue::get_issue(issue.as_str(), &config).await;
-    println!("{:?}", issue_details);
     let branch_name = template::interpret_branch_template(&config.config, issue_details?);
-    // checkout::checkout_branch(branch_name.as_str());
+    checkout::checkout_branch(branch_name.as_str());
     Ok(())
 }

--- a/src/jira.rs
+++ b/src/jira.rs
@@ -1,4 +1,5 @@
 pub mod client;
 pub mod issue;
+pub mod issue_url;
 pub mod auth;
 pub mod error;

--- a/src/jira/client.rs
+++ b/src/jira/client.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use crate::app_config::AppConfig;
 use crate::jira::error;
 
-pub async fn make_request<U: IntoUrl>(path: U, AppConfig {config, auth}: &AppConfig) -> Result<Response, String> {
+pub async fn make_request<U: IntoUrl>(path: U, AppConfig { config, auth }: &AppConfig) -> Result<Response, String> {
     let client = reqwest::Client::new();
     let url = format!("{}/rest/api/3/{}", config.base_url, path.as_str());
 

--- a/src/jira/issue.rs
+++ b/src/jira/issue.rs
@@ -1,9 +1,12 @@
+use std::collections::HashMap;
 use crate::jira::client;
 use serde::{Deserialize, Serialize};
+use url::{Url};
 use crate::app_config::{AppConfig, UserConfig};
 
-pub async fn get_issue(id: &str, config: &AppConfig) -> Result<JiraIssue, String> {
-    let ticket_id = prefix_id(id, &config.config);
+pub async fn get_issue(issue: &str, config: &AppConfig) -> Result<JiraIssue, String> {
+    let id = extract_id(issue);
+    let ticket_id = prefix_id(id.as_str(), &config.config);
     let url = format!("/issue/{}?fields=summary,issuetype", ticket_id);
     let response = client::make_request(
         url,
@@ -28,6 +31,35 @@ fn prefix_id(id: &str, config: &UserConfig) -> String {
     }
 
     id.to_string()
+}
+
+fn extract_id(issue: &str) -> String {
+    let url = Url::parse(issue);
+
+    match url {
+        Ok(u) => {
+            println!("Is URL: {:?}", u);
+            let params: HashMap<_, _> = u.query_pairs().into_owned().collect();
+            if let Some(selected_issue) = params.get("selectedIssue"){
+                println!("PARAMS: {:?}", selected_issue);
+                return String::from(selected_issue)
+            }
+
+            if u.path().starts_with("/browse/") {
+                if let Some(segments) =u.path_segments() {
+                    if let Some(item) = segments.last() {
+                        return String::from(item)
+                    }
+                }
+            }
+
+            u.to_string()
+        }
+        Err(_) => {
+            println!("Is NOT URL: {:?}", issue);
+            String::from(issue)
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/jira/issue_url.rs
+++ b/src/jira/issue_url.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+use url::Url;
+
+pub fn parse_url(url: Url) -> Result<String, &'static str> {
+    let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
+    if let Some(selected_issue) = params.get("selectedIssue"){
+        return Ok(selected_issue.to_string())
+    }
+
+    if url.path().starts_with("/browse/") {
+        if let Some(segments) =url.path_segments() {
+            if let Some(item) = segments.last() {
+                return Ok(item.to_string())
+            }
+        }
+    }
+
+    Err("Not a valid Jira issue URL")
+}

--- a/src/jira/issue_url.rs
+++ b/src/jira/issue_url.rs
@@ -3,14 +3,14 @@ use url::Url;
 
 pub fn parse_url(url: Url) -> Result<String, &'static str> {
     let params: HashMap<_, _> = url.query_pairs().into_owned().collect();
-    if let Some(selected_issue) = params.get("selectedIssue"){
-        return Ok(selected_issue.to_string())
+    if let Some(selected_issue) = params.get("selectedIssue") {
+        return Ok(selected_issue.to_string());
     }
 
     if url.path().starts_with("/browse/") {
-        if let Some(segments) =url.path_segments() {
+        if let Some(segments) = url.path_segments() {
             if let Some(item) = segments.last() {
-                return Ok(item.to_string())
+                return Ok(item.to_string());
             }
         }
     }


### PR DESCRIPTION
Allow the checkout command to be supplied with a Jira ticket URL instead of a ticket ID, as Jira makes copying an issue URL very easy in the UI, it can help speed up using the checkout feature.

The checkout command will now determine of the supplied issue argument is a URL, and attempt to retreive the ID from the URL. If the issue argument is not a URL, it will fallback to using the raw value supplied as before.

Updates the `issue-id` argument to `issue`, to better describe the intent.